### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ twitter-python
 
 Simple example scripts for Twitter data collection with [Tweepy](http://www.github.com/tweepy/tweepy) in Python
 
-#Getting started
+# Getting started
 To collect data you need a Twitter account and a Twitter application. Assuming you already have a Twitter account use the following instructions to create a Twitter application
 
-##Twitter application
+## Twitter application
 
 1. Open a web browser and go to https://apps.twitter.com/app/new
 2. Sign in with your normal Twitter username and password if you are not already signed in.
@@ -18,7 +18,7 @@ To collect data you need a Twitter account and a Twitter application. Assuming y
 8. You should now see new fields labeled "Access token" and "Access token secret" at the bottom of the page.
 9. You now have a Twitter application that can act on behalf of your Twitter user to read data from Twitter.
 
-##Connect your Twitter application to these scripts
+## Connect your Twitter application to these scripts
 1. Download the code in the repository if you haven't already
 2. Open the auth_example.py file in a text editor (gedit, kate, notepad, textmate, etc.)
 3. Update the following lines with the information displayed in the web browser for your application: 
@@ -35,7 +35,7 @@ To collect data you need a Twitter account and a Twitter application. Assuming y
 
 You are now ready to run a simple example.
 
-##First run (streaming_simple.py)
+## First run (streaming_simple.py)
 1. Open your terminal/console and go to the folder you saved the files (e.g. cd "/absolute path/to/my/files")
 2. Run streaming_simple.py by typing
    python streaming_simple.py
@@ -45,7 +45,7 @@ If you do not see tweets appearing, check that you have [Tweepy](http://www.gith
 
 In addition to printing out the text of tweets, streaming_simple.py also saves the results to output.json
 
-##Convert json to spreadsheet (data2spreadsheet.py)
+## Convert json to spreadsheet (data2spreadsheet.py)
 Twitter supplies tweets in JSON format. See the [Twitter documentation](https://dev.twitter.com/docs/platform-objects/tweets) for what fields are available. To create a spreadsheet of collected tweets, we can select certain fields and include these. This is what the data2spreadsheet.py file does. Note that this file does not include every possible field in a tweet. You may wish to modify the file if you need to include a particular field that is not currently included.
 
 The following steps assume you've run either streaming_simple.py or streaming.py and have file(s) of tweets with one tweet per line.
@@ -57,7 +57,7 @@ The following steps assume you've run either streaming_simple.py or streaming.py
 ```
 3. This will produce ``output/output_1234.tsv``,  where 1234 is the unix timestamp when the file was created (this is the number of seconds since January 1, 1970). The file can be opened in LibreOffice Calc, Excel, etc. If prompted select that columns (fields) are separated with a tab character.
 
-##Production (streaming.py)
+## Production (streaming.py)
 streaming.py is a more production ready file. It does not print tweets as they are recieved, but simply stores them to a files with the name of the day they are recieved on. It starts a new file at midnight every day. It also has additional error checking / recovery code.
 
 1. Create a directory (folder) to store the tweets in
@@ -70,7 +70,7 @@ streaming.py is a more production ready file. It does not print tweets as they a
     nohup python streaming.py >> logfile 2>> errorfile
 ```    
 
-##Reference
+## Reference
 If you use this code in support of an academic publication, please cite:
    
     Hale, S. A. (2014) Global Connectivity and Multilinguals in the Twitter Network. 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
